### PR TITLE
fix: Address actionlint issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   binary:
     name: Build Binary
-    runs-on: ubuntu-24.04-amd64
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,7 +39,7 @@ jobs:
 
   unit-tests:
     name: Unit Tests
-    runs-on: ubuntu-24.04-amd64
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -54,8 +54,8 @@ jobs:
 
   build:
     name: Build Packages
-    runs-on: ubuntu-24.04-amd64
-    needs: [binary, unit-tests]
+    runs-on: ubuntu-24.04
+    needs: [ binary, unit-tests ]
     permissions:
       contents: write
       id-token: write
@@ -94,8 +94,8 @@ jobs:
       - name: Setup Snapcraft
         run: |
           sudo snap install snapcraft --classic
-          mkdir -p $HOME/.cache/snapcraft/download
-          mkdir -p $HOME/.cache/snapcraft/stage-packages
+          mkdir -p "$HOME"/.cache/snapcraft/download
+          mkdir -p "$HOME"/.cache/snapcraft/stage-packages
         if: github.ref_type == 'tag'
 
       - name: Set up QEMU


### PR DESCRIPTION
* Fix runner specification
* Improve directory creation syntax in release workflow

### Proposed changes
ReviewDog issued the following warning:
```
[actionlint] reported by reviewdog 🐶
label "ubuntu-24.04-amd64" is unknown. available labels are "windows-latest", "windows-latest-8-cores", "windows-2025", "windows-2022", "windows-11-arm", "ubuntu-slim", "ubuntu-latest", "ubuntu-latest-4-cores", "ubuntu-latest-8-cores", "ubuntu-latest-16-cores", "ubuntu-24.04", "ubuntu-24.04-arm", "ubuntu-22.04", "ubuntu-22.04-arm", "macos-latest", "macos-latest-xlarge", "macos-latest-large", "macos-26-xlarge", "macos-26", "macos-15-intel", "macos-15-xlarge", "macos-15-large", "macos-15", "macos-14-xlarge", "macos-14-large", "macos-14", "self-hosted", "x64", "arm", "arm64", "linux", "macos", "windows". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]
```

This patch addresses the running specification, i.e. `ubuntu-24.04-amd64` should be `ubuntu-24.04`, there is no ubuntu-24.04-amd64, ubuntu-24.04 implies ubuntu-24.04.
As a side note, there is an entry for ARM, `ubuntu-24.04-arm`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-asg-sync/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
